### PR TITLE
Document aof2 rust api

### DIFF
--- a/rust/bop-rs/src/aof2/README.md
+++ b/rust/bop-rs/src/aof2/README.md
@@ -1,0 +1,123 @@
+# AOF2: Append-Only File Storage Engine
+
+AOF2 provides an append-only log with tiered caching, background flush, and sealed segment readers.
+
+## Key Types
+
+- `AofManager` / `AofManagerConfig`: bootstrap the background runtime and tiered store
+- `Aof`: per-instance append interface bound to an on-disk layout
+- `AofConfig`: configuration knobs (segment sizing, flush policy, retention, compression)
+- `RecordId`, `SegmentId`: record and segment identifiers
+- `SegmentReader`, `SegmentCursor`: read sealed segments
+- `TailFollower`, `SealedSegmentStream`: follow tail lifecycle and consume records
+
+## Quick Start
+
+```rust
+use bop_rs::aof2::{Aof, AofManager, AofManagerConfig};
+use bop_rs::aof2::config::{AofConfig, SegmentId};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = AofManager::with_config(AofManagerConfig::default())?;
+    let handle = manager.handle();
+
+    let mut cfg = AofConfig::default();
+    cfg.root_dir = std::path::PathBuf::from("/tmp/aof2-demo");
+    let aof = Aof::new(handle, cfg)?;
+
+    let rid = aof.append_record(b"hello world")?;
+    aof.flush_until(rid)?;
+
+    let seg_id = SegmentId::new(rid.segment_index() as u64);
+    if let Ok(reader) = aof.open_reader(seg_id) {
+        let rec = reader.read_record(rid)?;
+        assert_eq!(rec.payload(), b"hello world");
+    }
+    Ok(())
+}
+```
+
+## Async Append
+
+```rust
+use bop_rs::aof2::{Aof, AofManager, AofManagerConfig};
+use bop_rs::aof2::config::AofConfig;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manager = AofManager::with_config(AofManagerConfig::default())?;
+    let handle = manager.handle();
+    let aof = Aof::new(handle, AofConfig::default())?;
+    let _rid = aof.append_record_async(b"payload").await?;
+    Ok(())
+}
+```
+
+## Configuring Segment Sizes and Flush
+
+```rust
+use bop_rs::aof2::config::{AofConfig, FlushConfig, Compression, RetentionPolicy};
+
+let mut cfg = AofConfig::default();
+cfg.flush = FlushConfig { flush_watermark_bytes: 8 * 1024 * 1024, flush_interval_ms: 5, max_unflushed_bytes: 64 * 1024 * 1024 };
+cfg.segment_min_bytes = 2 * 1024 * 1024;
+cfg.segment_max_bytes = 128 * 1024 * 1024;
+cfg.segment_target_bytes = 16 * 1024 * 1024;
+cfg.compression = Compression::Zstd;
+cfg.retention = RetentionPolicy::KeepAll;
+let cfg = cfg.normalized();
+```
+
+## Reading Sealed Segments
+
+```rust
+use bop_rs::aof2::reader::SegmentCursor;
+use bop_rs::aof2::config::SegmentId;
+
+fn dump_segment(aof: &bop_rs::aof2::Aof, id: SegmentId) -> bop_rs::aof2::error::AofResult<()> {
+    let reader = aof.open_reader(id)?;
+    let mut cursor = SegmentCursor::new(reader);
+    while let Some(rec) = cursor.next()? {
+        println!("{} bytes", rec.payload().len());
+    }
+    Ok(())
+}
+```
+
+## Stream Sealed Then Active Tail
+
+```rust
+use bop_rs::aof2::reader::{SealedSegmentStream, StreamSegment};
+
+async fn consume(aof: &bop_rs::aof2::Aof) -> bop_rs::aof2::error::AofResult<()> {
+    let mut stream = SealedSegmentStream::new(aof)?;
+    while let Some(seg) = stream.next_segment().await? {
+        match seg {
+            StreamSegment::Sealed(mut cursor) => {
+                while let Some(rec) = cursor.next()? {
+                    // handle sealed record
+                }
+            }
+            StreamSegment::Active(mut cursor) => {
+                while let Some(rec) = cursor.next()? {
+                    // handle active record
+                }
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+## Metrics
+
+```rust
+use bop_rs::aof2::{FlushMetricsExporter, Aof};
+
+fn export(aof: &Aof) {
+    let snapshot = aof.flush_metrics();
+    let exporter = FlushMetricsExporter::new(snapshot);
+    exporter.emit(|sample| println!("{} {}", sample.name, sample.value));
+}
+```
+

--- a/rust/bop-rs/src/aof2/config.rs
+++ b/rust/bop-rs/src/aof2/config.rs
@@ -1,3 +1,21 @@
+//! Configuration types and identifiers for AOF2.
+//!
+//! These types define record and segment identifiers and all tuning knobs used by
+//! the `Aof` instance and its background services.
+//!
+//! Example: customize flush watermark and segment sizing
+//! ```rust
+//! use bop_rs::aof2::config::{AofConfig, FlushConfig, Compression, RetentionPolicy};
+//! let mut cfg = AofConfig::default();
+//! cfg.flush = FlushConfig { flush_watermark_bytes: 4 * 1024 * 1024, flush_interval_ms: 10, max_unflushed_bytes: 64 * 1024 * 1024 };
+//! cfg.segment_min_bytes = 2 * 1024 * 1024;
+//! cfg.segment_max_bytes = 256 * 1024 * 1024;
+//! cfg.segment_target_bytes = 16 * 1024 * 1024;
+//! cfg.compression = Compression::Zstd;
+//! cfg.retention = RetentionPolicy::KeepAll;
+//! let normalized = cfg.normalized();
+//! assert!(normalized.segment_min_bytes.is_power_of_two());
+//! ```
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 use std::path::PathBuf;

--- a/rust/bop-rs/src/aof2/error.rs
+++ b/rust/bop-rs/src/aof2/error.rs
@@ -1,7 +1,9 @@
+//! Error and result types for AOF2 operations.
 use std::fmt::{Display, Formatter};
 
 use super::config::{RecordId, SegmentId};
 
+/// Classification of backpressure reasons surfaced to callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackpressureKind {
     Admission,

--- a/rust/bop-rs/src/aof2/flush.rs
+++ b/rust/bop-rs/src/aof2/flush.rs
@@ -1,3 +1,7 @@
+//! Background flush scheduling and durability tracking.
+//!
+//! This module implements watermark/interval/backpressure-triggered flushes
+//! and exposes a `FlushManager` that coordinates async flush jobs.
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};

--- a/rust/bop-rs/src/aof2/fs.rs
+++ b/rust/bop-rs/src/aof2/fs.rs
@@ -1,3 +1,7 @@
+//! Filesystem utilities for AOF2 layout and file operations.
+//!
+//! Contains directory layout helpers, filename conventions, and fsync helpers
+//! used by segments and durability trackers.
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};

--- a/rust/bop-rs/src/aof2/manifest/chunk.rs
+++ b/rust/bop-rs/src/aof2/manifest/chunk.rs
@@ -1,3 +1,4 @@
+//! Fixed-size chunk representation used by the manifest log.
 use byteorder::{ByteOrder, LittleEndian};
 use crc64fast_nvme::Digest;
 

--- a/rust/bop-rs/src/aof2/manifest/inspect.rs
+++ b/rust/bop-rs/src/aof2/manifest/inspect.rs
@@ -1,3 +1,4 @@
+//! Helpers to inspect and summarize manifest state for debugging and tools.
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;

--- a/rust/bop-rs/src/aof2/manifest/mod.rs
+++ b/rust/bop-rs/src/aof2/manifest/mod.rs
@@ -1,3 +1,8 @@
+//! Manifest subsystem for per-segment metadata and inspection.
+//!
+//! This module coordinates reading/writing of per-segment manifests and exposes
+//! helpers to inspect and replay metadata for recovery. It is primarily used by
+//! the tier1 cache and not typically required by application code.
 mod chunk;
 mod inspect;
 mod reader;

--- a/rust/bop-rs/src/aof2/manifest/reader.rs
+++ b/rust/bop-rs/src/aof2/manifest/reader.rs
@@ -1,3 +1,4 @@
+//! Reading side of the manifest log and on-disk metadata.
 use std::fs::{self, File};
 use std::path::PathBuf;
 

--- a/rust/bop-rs/src/aof2/manifest/record.rs
+++ b/rust/bop-rs/src/aof2/manifest/record.rs
@@ -1,3 +1,4 @@
+//! Manifest record encodings and helpers.
 use std::io::{Cursor, Read};
 
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};

--- a/rust/bop-rs/src/aof2/manifest/writer.rs
+++ b/rust/bop-rs/src/aof2/manifest/writer.rs
@@ -1,3 +1,4 @@
+//! Writing side of the manifest log.
 use std::fs::{self, File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};

--- a/rust/bop-rs/src/aof2/metrics/admission.rs
+++ b/rust/bop-rs/src/aof2/metrics/admission.rs
@@ -1,3 +1,4 @@
+//! Metrics for admission and backpressure events.
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 

--- a/rust/bop-rs/src/aof2/metrics/manifest_replay.rs
+++ b/rust/bop-rs/src/aof2/metrics/manifest_replay.rs
@@ -1,3 +1,4 @@
+//! Metrics related to manifest replay during recovery.
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 

--- a/rust/bop-rs/src/aof2/metrics/mod.rs
+++ b/rust/bop-rs/src/aof2/metrics/mod.rs
@@ -1,3 +1,7 @@
+//! Metrics exposed by the AOF2 subsystem.
+//!
+//! These include admission metrics and manifest replay metrics. Public re-exports
+//! from the crate root surface the types needed by applications.
 //! Metric helpers for the async tiered AOF2 stack.
 
 pub mod admission;

--- a/rust/bop-rs/src/aof2/store/durability.rs
+++ b/rust/bop-rs/src/aof2/store/durability.rs
@@ -1,3 +1,4 @@
+//! Volatile durability cursor tracking per-segment flush progress.
 use std::collections::HashMap;
 
 use parking_lot::Mutex;

--- a/rust/bop-rs/src/aof2/store/mod.rs
+++ b/rust/bop-rs/src/aof2/store/mod.rs
@@ -1,3 +1,12 @@
+//! Tiered in-memory store that backs the AOF2 write path.
+//!
+//! The tiered store is composed of:
+//! - Tier0: admission/activation queue and eviction
+//! - Tier1: compressed resident segments and manifest
+//! - Tier2: optional remote object store integration
+//!
+//! Most applications interact with this via `AofManager`/`Aof` and do not need
+//! to use these types directly.
 // Tiered segment store modules
 
 mod durability;

--- a/rust/bop-rs/src/aof2/store/notifiers.rs
+++ b/rust/bop-rs/src/aof2/store/notifiers.rs
@@ -1,3 +1,4 @@
+//! Internal notification channels for admission and rollover events.
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};

--- a/rust/bop-rs/src/aof2/store/tier0.rs
+++ b/rust/bop-rs/src/aof2/store/tier0.rs
@@ -1,3 +1,4 @@
+//! Tier0: admission queue and residency tracking for active segments.
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::ops::Deref;

--- a/rust/bop-rs/src/aof2/store/tier1.rs
+++ b/rust/bop-rs/src/aof2/store/tier1.rs
@@ -1,3 +1,4 @@
+//! Tier1: resident segment cache, compression, and manifest integration.
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::fmt;

--- a/rust/bop-rs/src/aof2/store/tier2.rs
+++ b/rust/bop-rs/src/aof2/store/tier2.rs
@@ -1,3 +1,4 @@
+//! Tier2: optional remote object store backing for sealed segments.
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
Add comprehensive rustdoc comments and a README.md to the `aof2` module to document its public APIs and provide usage examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3b3cdfb-f07d-4690-938d-f7ee419f91d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3b3cdfb-f07d-4690-938d-f7ee419f91d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

